### PR TITLE
Install with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ I'm very much looking for help developing/testing this project so if you want to
 # Install the plug-in
 
 The plug-in is in very early days so it will be a while before (if) this makes it to pypi
-1. Clone the repository
-2. Run `make install` to install this to your environment
-3. Go to any Kedro 0.17.x project and see if it works! (Please let me know if it doesn't).
+1. Run `pip install git+https://github.com/datajoely/kedro-rich` to install this to your environment.
+2. Go to any Kedro 0.17.x project and see if it works! (Please let me know if it doesn't).
 
 ## Run end to end example:
 


### PR DESCRIPTION
Pip supports installing directly from a git repo, which should be much easier for most python folks.

## Description
No dependency on cloning or make.

## Development notes
this is how I installed it to try.

## Checklist


- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
