### PR TITLE
Flake8 config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
         args:
           - "--max-line-length=88"
           - "--max-complexity=18"
-          - "--max-complexity=18"
           - "--select=B,C,E,F,W,T4,B9"
           - "--ignore=E126,E203,E231,E266,E501,W503"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E126,E203,E231,E266,E501,W503
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
## Description

Flake8 is configured nicely in the `pre-commit` config, however there is no config for an editor to respect. I'm no expert here but vim was screaming at me till I added a `.flake8` but decided to go with `setup.cfg` since it's more generic. To my knowledge `pyproject.toml` doesn't support `flake8` (or vice versa).

If `setup.cfg` is undesirable for any reason I'm not married to it at all, but it's nice to have some canned config to avoid someone changing trivial things based on editor configs (ie. autoformat on save, or flake8 running in the background with a different config than what the project is setup for).

## Development notes

Removed duplicated config line in `.pre-commit-config` for `flake8`
Added `setup.cfg` with `flake8` config to match `pre-commit`

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
