### PR TITLE
Rename make commands to align with doc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Pull spaceflights and install kedro-rich in editable mode
-        run: make test-proj
+        run: make test-project
 
       - name: Kedro run (sequential)
         run: cd test_project; kedro run

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ uninstall-pre-commit:
 	pre-commit uninstall
 	pre-commit uninstall --hook-type pre-push
 
-test-proj:
+test-project:
 	pip install -e .
 	rm -rf test_project/
 	yes test_project | kedro new --starter=spaceflights

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The plug-in is in very early days so it will be a while before (if) this makes i
 
 ## Run end to end example
 
-Running `make test-project` then `make-test-run` will...
+Running `make test-project` then `make test-run` will...
 
 - Install the `kedro-rich` package into the environment
 - Pull the 'spaceflights' `kedro-starter`


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
Minor update, the current doc said `make test-project` but the Makefile and ci actually use `make test-proj`

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
